### PR TITLE
require one entry

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -15,6 +15,10 @@ argv._.map(function(arg) {
   argv.entries.push({from: parts[0], to: parts[1]})
 })
 
+if (!argv.entries.length) {
+  console.error('Usage: wzrd [filename]')
+  process.exit(1)
+}
 
 if (argv.https) {
   wzrd.https(argv, function(err, server) {


### PR DESCRIPTION
i didn't read the readme and wzrd gives a cryptic error message when running just `wzrd`

```
/usr/local/lib/node_modules/wzrd/index.js:38
      var firstEntry = opts.entries[0].to
                                      ^
TypeError: Cannot read property 'to' of undefined
    at /usr/local/lib/node_modules/wzrd/index.js:38:39
    at Object.cb [as oncomplete] (fs.js:169:19)
```

this fixes that by bailing if no entries were specified