### PR TITLE
--dir option

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -21,11 +21,6 @@ argv.entries = argv._.map(function(arg) {
     return {from: arg, to: arg}
   var parts = arg.split(':')
   return {from: parts[0], to: parts[1]}
-}).map(function(e) {
-  return {
-    from: path.join(argv.path, e.from),
-    to: e.to
-  }
 })
 
 argv.browserifyArgs = browserifyArgs

--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var minimist = require('minimist')
 var wzrd = require('./')
+var path = require('path')
 
 var args = process.argv.slice(2)
 var browserifyArgs
@@ -13,16 +14,18 @@ if (subIdx > -1) {
 var argv = minimist(args)
 
 var port = argv.port || argv.p || (argv.https ? 4443 : 9966)
+argv.path = argv.dir || argv.d || process.cwd()
 
-argv.entries = []
-
-argv._.map(function(arg) {
-  if (arg.indexOf(':') === -1) {
-    argv.entries.push({from: arg, to: arg})
-    return
-  }
+argv.entries = argv._.map(function(arg) {
+  if (arg.indexOf(':') === -1)
+    return {from: arg, to: arg}
   var parts = arg.split(':')
-  argv.entries.push({from: parts[0], to: parts[1]})
+  return {from: parts[0], to: parts[1]}
+}).map(function(e) {
+  return {
+    from: path.join(argv.path, e.from),
+    to: e.to
+  }
 })
 
 argv.browserifyArgs = browserifyArgs

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ module.exports.static = function(opts) {
   
   opts.entries.forEach(function(entry) {
     router.addRoute('/' + entry.to, function(req, res, params) {
-      module.exports.browserify(entry.from, opts, req, res)
+      var from = path.join(basedir, entry.from)
+      module.exports.browserify(from, opts, req, res)
     })
   })
   


### PR DESCRIPTION
Adding `--dir` option. This is a breaking API change since the `from` is now resolved using the `path` option. 

eg

```
wzrd test.js:bundle.js --dir test
```

Would work with the following folder structure:

```
test/
    test.js
    bundle.js
    index.html
    image.png
```

Thoughts? Will add some tests shortly. 
