### PR TITLE
#9 Added pushstate option

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports.static = function(opts) {
   router.addRoute('*', function(req, res, params) {
     console.log(JSON.stringify({url: req.url, type: 'static', time: new Date()}))
     staticHandler(req, res, function() {
-      if (opts['force-index']) return indexHtmlHandler(req, res)
+      if (opts.pushstate) return indexHtmlHandler(req, res)
       res.end('File not found. :(')
     })
   })

--- a/index.js
+++ b/index.js
@@ -26,26 +26,31 @@ module.exports.static = function(opts) {
   var basedir = opts.path || process.cwd()
   var staticHandler = ecstatic(basedir)
   var router = Router()
-  
-  opts.entries.forEach(function(entry) {
-    router.addRoute('/' + entry.to, function(req, res, params) {
-      module.exports.browserify(entry.from, opts, req, res)
-    })
-  })
-  
-  router.addRoute('/', function(req, res, params) {
+
+  var indexHtmlHandler = function(req, res, params) {
     fs.exists(path.join(basedir, 'index.html'), function(exists) {
       var firstEntry = opts.entries[0].to
       if (exists) return staticHandler(req, res)
       else module.exports.generateIndex(firstEntry, req, res)
     })
+  }
+
+  opts.entries.forEach(function(entry) {
+    router.addRoute('/' + entry.to, function(req, res, params) {
+      module.exports.browserify(entry.from, opts, req, res)
+    })
   })
-  
+
+  router.addRoute('/', indexHtmlHandler)
+
   router.addRoute('*', function(req, res, params) {
     console.log(JSON.stringify({url: req.url, type: 'static', time: new Date()}))
-    staticHandler(req, res)
+    staticHandler(req, res, function() {
+      if (opts['force-index']) return indexHtmlHandler(req, res)
+      res.end('File not found. :(')
+    })
   })
-  
+
   return router
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wzrd",
+  "name": "@twilson63/wzrd",
   "version": "1.2.1",
   "description": "Super minimal browserify development server. Inspired by [beefy](http://npmjs.org/beefy) but with less magic",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilson63/wzrd",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Super minimal browserify development server. Inspired by [beefy](http://npmjs.org/beefy) but with less magic",
   "bin": {
     "wzrd": "bin.js"

--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,11 @@ wzrd app.js -- -t brfs
 ```
 
 anything after `--` will get passed directly to `browserify` as arguments. so the example above would spawn the command `browserify app.js -t brfs`
+
+### pushstate server support
+
+```
+wzrd app.js --pushstate
+```
+
+if you want to leverage the html5 pushstate and support natural urls in your frontend application you can use the `--pushstate` flag. This flag will instruct the wzrd server to always return index.html for any file not found request from your server.


### PR DESCRIPTION
This option instructs the wzrd server to always return index.html for any url not found by the server.  This feature enables html5 pushstate to work and allows the application to use natural urls instead of hash based urls:

eg: 

/widgets/1234

instead of

/#/widgets/1234

