### PR TITLE
Show additional available hosts on server startup

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var minimist = require('minimist')
 var portfinder = require('portfinder')
+var os = require( 'os' );
 var wzrd = require('./')
 
 var args = process.argv.slice(2)
@@ -58,6 +59,14 @@ portfinder.getPort(function(err, port) {
       process.exit(1)
     }
     console.error('server started at ' + (argv.https ? 'https' : 'http') + '://localhost:' + port)
+
+    var ifaces = os.networkInterfaces()
+    Object.keys(ifaces).forEach(function (ifname) {
+        ifaces[ifname].forEach(function (iface) {
+            if ('IPv4' === iface.family) {
+                console.error('also available at ' + (argv.https ? 'https' : 'http') + '://' + iface.address + ':' + port)
+            }
+        });
+    });
   }
 })
-

--- a/bin.js
+++ b/bin.js
@@ -40,7 +40,7 @@ portfinder.getPort(function(err, port) {
     console.error('error finding port', err)
     process.exit(1)
   }
-  
+
   if (argv.https) {
     wzrd.https(argv, function(err, server) {
       if (err) {
@@ -58,13 +58,13 @@ portfinder.getPort(function(err, port) {
       console.error('error starting server', err)
       process.exit(1)
     }
-    console.error('server started at ' + (argv.https ? 'https' : 'http') + '://localhost:' + port)
+    console.error('server started at:');
 
     var ifaces = os.networkInterfaces()
     Object.keys(ifaces).forEach(function (ifname) {
         ifaces[ifname].forEach(function (iface) {
             if ('IPv4' === iface.family) {
-                console.error('also available at ' + (argv.https ? 'https' : 'http') + '://' + iface.address + ':' + port)
+                console.error((argv.https ? 'https' : 'http') + '://' + iface.address + ':' + port)
             }
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -13,8 +13,9 @@ var noop = function(){}
 var cliPath =  path.resolve(__dirname, '..', 'bin.js')
 
 function run(t, port, cb) {
-  var server = 'http://localhost:'+port
-  var startMsg = 'server started at '+server
+  var ipList = getIPList()
+  var server = 'http://' + ipList[0] + ':'+port
+  var startMsg = 'server started at:'
   var proc = spawn(cliPath, ['app.js'], { cwd: __dirname, env: process.env })
   waitFor(startMsg, proc.stderr, function(output) {
     t.ok(output.indexOf(startMsg) > -1, startMsg)
@@ -37,7 +38,7 @@ test('single entry', function(t) {
 
 test('portfinder', function(t) {
   var server = require('http').createServer()
-  
+
   server.listen(9966, function() {
       run(t, 9967, function() {
         t.end()
@@ -61,4 +62,17 @@ function waitFor(string, stream, cb) {
   stream.on('end', function() {
     if (!done) cb('')
   })
+}
+
+function getIPList() {
+    var ifaces = os.networkInterfaces()
+    var ipList = [];
+    Object.keys(ifaces).forEach(function (ifname) {
+        ifaces[ifname].forEach(function (iface) {
+            if ('IPv4' === iface.family) {
+                ipList.push(iface.address);
+            }
+        });
+    });
+    return ipList;
 }


### PR DESCRIPTION
This outputs additional ipv4 based host names to the console on server start
```
server started at http://localhost:9966
also available at http://127.0.0.1:9966
also available at http://192.168.1.1:9966
```
This fixes #16 which I opened a few weeks ago.

