### PR TITLE
updated ecstatic to ^1.4.1 because of language support problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "BSD",
   "dependencies": {
     "concat-stream": "^1.4.7",
-    "ecstatic": "^0.5.8",
+    "ecstatic": "^1.4.1",
     "minimist": "^1.1.0",
     "npm-execspawn": "^1.0.6",
     "pem": "^1.4.4",


### PR DESCRIPTION
Updated Ecstatic version to `^1.4.1`. In previous version there was some problem with non-english language i.e. server crashed on producting etag header, like so:

```
_http_outgoing.js:351
      throw new TypeError('The header content contains invalid characters');
      ^

TypeError: The header content contains invalid characters
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:351:13)
    at serve (C:\Users\jansw\AppData\Roaming\npm\node_modules\wzrd\node_modules\ecstatic\lib\ecstatic.js:205:11)
    at C:\Users\jansw\AppData\Roaming\npm\node_modules\wzrd\node_modules\ecstatic\lib\ecstatic.js:138:11
    at FSReqWrap.oncomplete (fs.js:82:15)
```

It tried to set `etag: 1970324836979805-6-Tue Aug 09 2016 14:48:11 GMT+0200 (Środkowoeuropejski czas letni)` and it didn't work for "Ś" character.

This pull requests fixes that.

I've run `npm test` on Node v4 on Windows 10.
